### PR TITLE
updates to behavior

### DIFF
--- a/krl.sh
+++ b/krl.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 [ $# -ge 1 -a "$1" ] && input="$1" || read input
-link=`curl --silent --data "" http://krl.io/v1/link/$1 | tr -d '"'`
+newInput=$(echo $input | sed -e 's/^http:\/\///g' -e 's/^https:\/\///g')
+echo $newInput
+link=`curl --silent --data "" http://krl.io/v1/link/$newInput | tr -d '"' | sed 's|{url:||g' | tr -d '}'`
 echo -ne $link
-echo ""

--- a/krl.sh
+++ b/krl.sh
@@ -2,6 +2,5 @@
 #
 [ $# -ge 1 -a "$1" ] && input="$1" || read input
 newInput=$(echo $input | sed -e 's/^http:\/\///g' -e 's/^https:\/\///g')
-echo $newInput
 link=`curl --silent --data "" http://krl.io/v1/link/$newInput | tr -d '"' | sed 's|{url:||g' | tr -d '}'`
 echo -ne $link


### PR DESCRIPTION
This change allows urls to be submitted to the command line with a leading `http://` or `https://` and changes the output to just the url to the shortened link with no newline so you can do things like: 
`pbpaste | krl | pbcopy` and then paste the link inline wherever you would like